### PR TITLE
Feat/crud for user service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ charset-normalizer==3.4.1
 click==8.1.8
 cryptography==44.0.0
 ecdsa==0.19.0
+email-validator==2.1.1
 exceptiongroup==1.2.2
 fastapi==0.115.7
 firebase-admin==6.6.0

--- a/src/database.py
+++ b/src/database.py
@@ -1,12 +1,29 @@
+import os
+
 import firebase_admin
-from firebase_admin import auth, credentials, firestore
+from firebase_admin import auth, credentials
+from google.cloud import firestore
+from google.oauth2 import service_account
 
-cred = credentials.Certificate("kusis-kr-firebase-adminsdk.json")
-firebase_admin.initialize_app(cred)
+
+def initialize_firebase_admin():
+    if not firebase_admin._apps:
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        key_path = os.path.join(current_dir, "kusis-kr-firebase-adminsdk.json")
+
+        if not os.path.exists(key_path):
+            raise FileNotFoundError(f"서비스 계정 키 파일을 찾을 수 없습니다: {key_path}")
+
+        cred = credentials.Certificate(key_path)
+        firebase_admin.initialize_app(cred)
 
 
-def get_firestore_client():
-    return firestore.client()
+def get_async_firestore_client() -> firestore.AsyncClient:
+    initialize_firebase_admin()
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    key_path = os.path.join(current_dir, "kusis-kr-firebase-adminsdk.json")
+    creds = service_account.Credentials.from_service_account_file(key_path)
+    return firestore.AsyncClient(credentials=creds)
 
 
 def get_auth_client():

--- a/src/dependency.py
+++ b/src/dependency.py
@@ -1,18 +1,18 @@
 from typing import Any, Dict
 
 from fastapi import Depends, Header, HTTPException, status
-from google.cloud.firestore_v1.client import Client
+from google.cloud.firestore_v1.async_client import AsyncClient
 from jose import jwt
 from jwt import PyJWTError
 
 from config import Settings
-from database import get_firestore_client
+from database import get_async_firestore_client
 from exception import InactiveUserException
 
 
 async def get_current_admin(
     token: str = Header(None),
-    db: Client = Depends(get_firestore_client)
+    db: AsyncClient = Depends(get_async_firestore_client)
 ):
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,

--- a/src/domain/schema/auth_schemas.py
+++ b/src/domain/schema/auth_schemas.py
@@ -1,23 +1,35 @@
-from pydantic import BaseModel
+from datetime import datetime
+
+from pydantic import BaseModel, EmailStr, Field
 
 
 class RouteReqAdminLogin(BaseModel):
-    email: str
-    password: str
+    email: EmailStr = Field(title="email", description="관리자 이메일")
+    password: str = Field(title="password", description="관리자 비밀번호")
 
 
 class RouteResAdminLogin(BaseModel):
-    access_token: str
-    refresh_token: str
-    token_type: str = "bearer"
+    access_token: str = Field(title="access_token", description="액세스 토큰")
+    refresh_token: str = Field(title="refresh_token", description="리프레시 토큰")
+    token_type: str = Field("bearer", title="token_type", description="토큰 타입")
 
 
 class RouteReqUserRegister(BaseModel):
-    email: str
-    password: str
-    name: str
+    email: EmailStr = Field(title="email", description="사용자 이메일")
+    password: str = Field(title="password", description="사용자 비밀번호")
+    name: str = Field(title="name", description="사용자 이름")
 
 
 class RouteResUserRegister(BaseModel):
-    email: str
-    name: str
+    email: EmailStr = Field(title="email", description="사용자 이메일")
+    name: str = Field(title="name", description="사용자 이름")
+
+
+class RouteResGetUser(BaseModel):
+    email: EmailStr = Field(title="email", description="사용자 이메일")
+    name: str = Field(title="name", description="사용자 이름")
+    created_at: datetime = Field(datetime.now(), title="created_at", description="사용자 생성일")
+    updated_at: datetime = Field(datetime.now(), title="updated_at", description="사용자 최종 수정일")
+    is_admin: bool = Field(False, title="is_admin", description="관리자: True, 사용자: False")
+    is_active: bool = Field(True, title="is_active", description="활성: True, 비활성: False")
+    is_deleted: bool = Field(False, title="is_deleted", description="삭제: True, 미삭제: False")

--- a/src/domain/schema/auth_schemas.py
+++ b/src/domain/schema/auth_schemas.py
@@ -3,29 +3,45 @@ from datetime import datetime
 from pydantic import BaseModel, EmailStr, Field
 
 
-class RouteReqAdminLogin(BaseModel):
+class RouteReqLoginAdmin(BaseModel):
     email: EmailStr = Field(title="email", description="관리자 이메일")
     password: str = Field(title="password", description="관리자 비밀번호")
 
 
-class RouteResAdminLogin(BaseModel):
+class RouteResLoginAdmin(BaseModel):
     access_token: str = Field(title="access_token", description="액세스 토큰")
     refresh_token: str = Field(title="refresh_token", description="리프레시 토큰")
     token_type: str = Field("bearer", title="token_type", description="토큰 타입")
 
 
-class RouteReqUserRegister(BaseModel):
+class RouteReqRegisterUser(BaseModel):
     email: EmailStr = Field(title="email", description="사용자 이메일")
     password: str = Field(title="password", description="사용자 비밀번호")
     name: str = Field(title="name", description="사용자 이름")
 
 
-class RouteResUserRegister(BaseModel):
+class RouteResRegisterUser(BaseModel):
     email: EmailStr = Field(title="email", description="사용자 이메일")
     name: str = Field(title="name", description="사용자 이름")
 
 
 class RouteResGetUser(BaseModel):
+    email: EmailStr = Field(title="email", description="사용자 이메일")
+    name: str = Field(title="name", description="사용자 이름")
+    created_at: datetime = Field(datetime.now(), title="created_at", description="사용자 생성일")
+    updated_at: datetime = Field(datetime.now(), title="updated_at", description="사용자 최종 수정일")
+    is_admin: bool = Field(False, title="is_admin", description="관리자: True, 사용자: False")
+    is_active: bool = Field(True, title="is_active", description="활성: True, 비활성: False")
+    is_deleted: bool = Field(False, title="is_deleted", description="삭제: True, 미삭제: False")
+
+
+class RouteReqUpdateUser(BaseModel):
+    name: str | None = Field(title="name", description="사용자 이름")
+    is_admin: bool | None = Field(False, title="is_admin", description="관리자: True, 사용자: False")
+    is_active: bool | None = Field(True, title="is_active", description="활성: True, 비활성: False")
+
+
+class RouteResUpdateUser(BaseModel):
     email: EmailStr = Field(title="email", description="사용자 이메일")
     name: str = Field(title="name", description="사용자 이름")
     created_at: datetime = Field(datetime.now(), title="created_at", description="사용자 생성일")

--- a/src/domain/schema/content_schemas.py
+++ b/src/domain/schema/content_schemas.py
@@ -25,6 +25,15 @@ class RouteResGetContent(BaseModel):
     title: str = Field(title="title", description="게시글 제목")
     contents: str = Field(title="contents", description="게시글 내용")
     images: list[str] = Field([], title="images", description="이미지 URL 모음")
+    updated_at: datetime = Field(datetime.now(), title="updated_at", description="게시글 최종 수정일")
+
+
+class RouteResGetContentDetail(BaseModel):
+    content_id: str = Field(title="content_id", description="게시글 ID")
+    post_number: int = Field(title="post_number", description="게시글 Post Number")
+    title: str = Field(title="title", description="게시글 제목")
+    contents: str = Field(title="contents", description="게시글 내용")
+    images: list[str] = Field([], title="images", description="이미지 URL 모음")
     created_at: datetime = Field(datetime.now(), title="created_at", description="게시글 작성일")
     updated_at: datetime = Field(datetime.now(), title="updated_at", description="게시글 최종 수정일")
     is_deleted: bool = Field(False, title="is_deleted", description="삭제: True, 미삭제: False")

--- a/src/domain/schema/content_schemas.py
+++ b/src/domain/schema/content_schemas.py
@@ -40,3 +40,9 @@ class RouteResGetContentList(BaseModel):
     data: list[RouteResContentSummary] = Field([], description="게시글 요약 정보 리스트")
     count: int = Field(description="현재 페이지 게시글 수")
     total: int = Field(description="전체 게시글 수")
+
+
+class RouteReqPutContent(BaseModel):
+    title: str | None = Field(title="title", description="게시글 제목")
+    contents: str | None = Field(title="contents", description="게시글 내용")
+    images: list[str] | None = Field([], title="images", description="이미지 URL 모음")

--- a/src/domain/schema/content_schemas.py
+++ b/src/domain/schema/content_schemas.py
@@ -45,4 +45,4 @@ class RouteResGetContentList(BaseModel):
 class RouteReqPutContent(BaseModel):
     title: str | None = Field(title="title", description="게시글 제목")
     contents: str | None = Field(title="contents", description="게시글 내용")
-    images: list[str] | None = Field([], title="images", description="이미지 URL 모음")
+    images: list[str] | None = Field(title="images", description="이미지 URL 모음")

--- a/src/domain/service/content_services.py
+++ b/src/domain/service/content_services.py
@@ -2,11 +2,11 @@ from datetime import datetime
 from typing import Annotated
 
 from fastapi import Depends, HTTPException, status
-from google.cloud.firestore_v1.base_query import BaseCompositeFilter, FieldFilter
-from google.cloud.firestore_v1.client import Client
+from google.cloud.firestore_v1.async_client import AsyncClient
+from google.cloud.firestore_v1.base_query import And, FieldFilter
 from zoneinfo import ZoneInfo
 
-from database import get_firestore_client
+from database import get_async_firestore_client
 from domain.schema.content_schemas import (
     RouteReqPostContent,
     RouteReqPutContent,
@@ -15,38 +15,23 @@ from domain.schema.content_schemas import (
     RouteResGetContentDetail,
     RouteResGetContentList,
 )
+from utils.crud_utils import FirestoreService
 
 
 async def service_get_content(
     post_number: int,
-    db: Annotated[Client, Depends(get_firestore_client)],
+    db: Annotated[AsyncClient, Depends(get_async_firestore_client)],
 ) -> RouteResGetContent:
-    # Query for the document with matching post_number and not deleted
-    contents_query = (
-        db.collection("contents")
-        .where(
-            filter=BaseCompositeFilter(
-                "AND", [
-                    FieldFilter("post_number", "==", post_number),
-                    FieldFilter("is_deleted", "==", False)
-                ]
-            )
-        )
-        .limit(1)
-    )
-    contents = contents_query.get()
-
-    if not contents or len(contents) == 0:
+    # Get document by increment ID (post_number)
+    content_data = await FirestoreService(db).get_document_by_increment_id("contents", "post_number", post_number)
+    if content_data is None or content_data.get("is_deleted", True):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Content not found"
         )
 
-    content_doc = contents[0]
-    content_data = content_doc.to_dict()
-
     response = RouteResGetContent(
-        content_id=content_doc.id,
+        content_id=content_data["document_id"],
         post_number=content_data["post_number"],
         title=content_data["title"],
         contents=content_data["contents"],
@@ -59,25 +44,29 @@ async def service_get_content(
 async def service_get_content_list(
     page: int,
     limit: int,
-    db: Annotated[Client, Depends(get_firestore_client)],
+    db: Annotated[AsyncClient, Depends(get_async_firestore_client)],
 ) -> RouteResGetContentList:
     # Calculate offset for pagination
     offset = (page - 1) * limit
 
     # Get total count of non-deleted contents
     total_query = db.collection("contents").where(filter=FieldFilter("is_deleted", "==", False))
-    total_docs = total_query.get()
-    total_count = len(list(total_docs))
+    total_docs = await total_query.get()
+    total_count = len(total_docs)
 
-    # Get paginated contents
+    # Get paginated contents using And filter
     contents_query = (
         db.collection("contents")
-        .where(filter=FieldFilter("is_deleted", "==", False))
+        .where(
+            filter=And([
+                FieldFilter("is_deleted", "==", False)
+            ])
+        )
         .order_by("post_number", direction="DESCENDING")
         .offset(offset)
         .limit(limit)
     )
-    contents = contents_query.get()
+    contents = await contents_query.get()
 
     content_list = []
     for content in contents:
@@ -91,66 +80,64 @@ async def service_get_content_list(
             )
         )
 
-    return RouteResGetContentList(
+    response = RouteResGetContentList(
         data=content_list,
         count=len(content_list),
         total=total_count
     )
+    return response
 
 
 async def service_create_content(
     content: RouteReqPostContent,
-    db: Annotated[Client, Depends(get_firestore_client)],
+    db: Annotated[AsyncClient, Depends(get_async_firestore_client)],
 ) -> RouteResGetContent:
-    # Get the next post number
-    contents_ref = db.collection("contents")
-    latest_content = contents_ref.order_by("post_number", direction="DESCENDING").limit(1).get()
-    next_post_number = 1
-    if latest_content and len(latest_content) > 0:
-        next_post_number = latest_content[0].to_dict().get("post_number", 0) + 1
-        """재설계 필요"""
-
     # Get current timestamp in KST
     now = datetime.now(ZoneInfo("Asia/Seoul"))
 
     # Prepare content data
     content_data = content.model_dump()
     content_data.update({
-        "post_number": next_post_number,
         "created_at": now,
         "updated_at": now,
         "is_deleted": False
     })
 
-    # Create the document with auto-generated ID
-    doc_ref = contents_ref.document()
-    doc_ref.set(content_data)
+    # Create document with auto-increment ID
+    result = await FirestoreService(db).create_document_with_increment_id("contents", "post_number", content_data)
+    if result is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create content"
+        )
 
-    return RouteResGetContent(
-        content_id=doc_ref.id,
+    # Update content data with the generated ID
+    content_data["post_number"] = result["post_number"]
+
+    response = RouteResGetContent(
+        content_id=result["document_id"],
         **content_data
     )
+    return response
 
 
 async def service_update_content(
     post_number: int,
     request: RouteReqPutContent,
-    db: Annotated[Client, Depends(get_firestore_client)],
+    db: Annotated[AsyncClient, Depends(get_async_firestore_client)],
 ) -> RouteResGetContent:
     # Query for the document with matching post_number and not deleted
     contents_query = (
         db.collection("contents")
         .where(
-            filter=BaseCompositeFilter(
-                "AND", [
-                    FieldFilter("post_number", "==", post_number),
-                    FieldFilter("is_deleted", "==", False)
-                ]
-            )
+            filter=And([
+                FieldFilter("post_number", "==", post_number),
+                FieldFilter("is_deleted", "==", False)
+            ])
         )
         .limit(1)
     )
-    contents = contents_query.get()
+    contents = await contents_query.get()
 
     if not contents or len(contents) == 0:
         raise HTTPException(
@@ -170,35 +157,35 @@ async def service_update_content(
         content_data.update({
             "updated_at": datetime.now(ZoneInfo("Asia/Seoul"))
         })
-        # Update using the correct document reference
-        db.collection("contents").document(content_doc.id).update(content_data)
+        # Update using the correct document reference with await
+        await db.collection("contents").document(content_doc.id).update(content_data)
 
     # Get the updated document
-    updated_doc = db.collection("contents").document(content_doc.id).get()
-    return RouteResGetContent(
+    updated_doc = await db.collection("contents").document(content_doc.id).get()
+
+    response = RouteResGetContent(
         content_id=content_doc.id,
         **updated_doc.to_dict()
     )
+    return response
 
 
 async def service_delete_content(
     post_number: int,
-    db: Annotated[Client, Depends(get_firestore_client)],
+    db: Annotated[AsyncClient, Depends(get_async_firestore_client)],
 ) -> None:
     # Query for the document with matching post_number and not deleted
     contents_query = (
         db.collection("contents")
         .where(
-            filter=BaseCompositeFilter(
-                "AND", [
-                    FieldFilter("post_number", "==", post_number),
-                    FieldFilter("is_deleted", "==", False)
-                ]
-            )
+            filter=And([
+                FieldFilter("post_number", "==", post_number),
+                FieldFilter("is_deleted", "==", False)
+            ])
         )
         .limit(1)
     )
-    contents = contents_query.get()
+    contents = await contents_query.get()
 
     if not contents or len(contents) == 0:
         raise HTTPException(
@@ -207,30 +194,28 @@ async def service_delete_content(
         )
 
     content_doc = contents[0]
-    # Update using the correct document reference
-    db.collection("contents").document(content_doc.id).update({"is_deleted": True})
+    # Update using the correct document reference with await
+    await db.collection("contents").document(content_doc.id).update({"is_deleted": True})
 
     return
 
 
 async def service_get_content_detail(
     post_number: int,
-    db: Annotated[Client, Depends(get_firestore_client)],
+    db: Annotated[AsyncClient, Depends(get_async_firestore_client)],
 ) -> RouteResGetContentDetail:
     # Query for the document with matching post_number and not deleted
     contents_query = (
         db.collection("contents")
         .where(
-            filter=BaseCompositeFilter(
-                "AND", [
-                    FieldFilter("post_number", "==", post_number),
-                    FieldFilter("is_deleted", "==", False)
-                ]
-            )
+            filter=And([
+                FieldFilter("post_number", "==", post_number),
+                FieldFilter("is_deleted", "==", False)
+            ])
         )
         .limit(1)
     )
-    contents = contents_query.get()
+    contents = await contents_query.get()
 
     if not contents or len(contents) == 0:
         raise HTTPException(

--- a/src/domain/service/counter_services.py
+++ b/src/domain/service/counter_services.py
@@ -1,0 +1,52 @@
+# services/counter_service.py
+import asyncio
+from typing import Annotated
+
+from fastapi import Depends
+from google.api_core.exceptions import GoogleAPICallError, RetryError
+from google.cloud.firestore_v1.async_client import AsyncClient
+
+from database import get_async_firestore_client
+
+
+async def get_async_next_id(
+    collection_name: str,
+    db: Annotated[AsyncClient, Depends(get_async_firestore_client)]
+) -> int | None:
+    counter_ref = db.collection("counters").document(collection_name)
+    max_retries = 5
+    base_delay = 0.1  # 100ms
+    async def attempt_transaction() -> int:
+        transaction = db.transaction()
+        await transaction._begin()
+
+        # Get the current counter value
+        snapshot = await counter_ref.get(transaction=transaction)
+        if snapshot.exists:
+            current_count = snapshot.to_dict().get('count', 0)
+            next_id = current_count + 1
+            transaction.update(counter_ref, {"count": next_id})
+        else:
+            next_id = 1
+            transaction.set(counter_ref, {"count": next_id})
+
+        # Commit the transaction
+        await transaction._commit()
+        return next_id
+
+    for attempt in range(max_retries):
+        try:
+            return await attempt_transaction()
+        except (GoogleAPICallError, RetryError) as e:
+            # Handle specific Firestore exceptions
+            if attempt == max_retries - 1:
+                print(f"Firestore transaction error after {max_retries} attempts: {e}")
+                return None
+            # Exponential backoff with jitter
+            delay = base_delay * (2 ** attempt) * (0.5 + asyncio.random.random())
+            await asyncio.sleep(delay)
+        except Exception as e:
+            # Handle any other exceptions
+            print(f"Unexpected error: {e}")
+            return None
+    return None

--- a/src/route/auth_route.py
+++ b/src/route/auth_route.py
@@ -13,6 +13,7 @@ from domain.schema.auth_schemas import (
     RouteResUpdateUser,
 )
 from domain.service.auth_services import (
+    service_delete_user,
     service_get_user,
     service_login_admin,
     service_register_user,
@@ -94,7 +95,7 @@ async def update_admin(
     request: RouteReqUpdateUser,
     current_user: Annotated[dict, Depends(get_current_active_admin)],
     db = Depends(get_firestore_client),
-):
+) -> RouteResUpdateUser:
     result = await service_update_user(
         uid=uid,
         request=request,
@@ -102,3 +103,22 @@ async def update_admin(
     )
 
     return result
+
+
+@router.delete(
+    "/admin/{uid}",
+    summary="사용자 삭제",
+    description="""사용자 삭제""",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_admin(
+    uid: str,
+    current_user: Annotated[dict, Depends(get_current_active_admin)],
+    db = Depends(get_firestore_client),
+) -> None:
+    await service_delete_user(
+        uid=uid,
+        db=db
+    )
+
+    return

--- a/src/route/auth_route.py
+++ b/src/route/auth_route.py
@@ -52,12 +52,14 @@ async def login_admin(
     status_code=status.HTTP_200_OK,
 )
 async def register_user(
-    request: RouteReqRegisterUser
+    request: RouteReqRegisterUser,
+    db = Depends(get_async_firestore_client),
 ):
     result = await service_register_user(
         email=request.email,
         password=request.password,
-        name=request.name
+        name=request.name,
+        db=db,
     )
 
     return result

--- a/src/route/auth_route.py
+++ b/src/route/auth_route.py
@@ -4,13 +4,20 @@ from fastapi import APIRouter, Depends, status
 
 from dependency import get_current_active_admin, get_firestore_client
 from domain.schema.auth_schemas import (
-    RouteReqAdminLogin,
-    RouteReqUserRegister,
-    RouteResAdminLogin,
+    RouteReqLoginAdmin,
+    RouteReqRegisterUser,
+    RouteReqUpdateUser,
     RouteResGetUser,
-    RouteResUserRegister,
+    RouteResLoginAdmin,
+    RouteResRegisterUser,
+    RouteResUpdateUser,
 )
-from domain.service.auth_services import service_get_user, service_login_admin, service_register_user
+from domain.service.auth_services import (
+    service_get_user,
+    service_login_admin,
+    service_register_user,
+    service_update_user,
+)
 
 router = APIRouter(
     prefix="/auth",
@@ -22,12 +29,12 @@ router = APIRouter(
     "/admin/login",
     summary="관리자 로그인",
     description="관리자 로그인",
-    response_model=RouteResAdminLogin,
+    response_model=RouteResLoginAdmin,
     status_code=status.HTTP_200_OK,
 )
 async def login_admin(
-    login_data: RouteReqAdminLogin
-) -> RouteResAdminLogin:
+    login_data: RouteReqLoginAdmin
+) -> RouteResLoginAdmin:
     result = await service_login_admin(
         email=login_data.email,
         password=login_data.password
@@ -40,11 +47,11 @@ async def login_admin(
     "/user/register",
     summary="사용자 회원가입",
     description="사용자 회원가입",
-    response_model=RouteResUserRegister,
+    response_model=RouteResRegisterUser,
     status_code=status.HTTP_200_OK,
 )
 async def register_user(
-    request: RouteReqUserRegister
+    request: RouteReqRegisterUser
 ):
     result = await service_register_user(
         email=request.email,
@@ -74,3 +81,24 @@ async def get_admin(
 
     return result
 
+
+@router.put(
+    "/admin/{uid}",
+    summary="사용자 정보 수정",
+    description="""사용자 정보 수정""",
+    response_model=RouteResUpdateUser,
+    status_code=status.HTTP_200_OK,
+)
+async def update_admin(
+    uid: str,
+    request: RouteReqUpdateUser,
+    current_user: Annotated[dict, Depends(get_current_active_admin)],
+    db = Depends(get_firestore_client),
+):
+    result = await service_update_user(
+        uid=uid,
+        request=request,
+        db=db
+    )
+
+    return result

--- a/src/route/auth_route.py
+++ b/src/route/auth_route.py
@@ -40,7 +40,6 @@ async def login_admin(
         email=login_data.email,
         password=login_data.password
     )
-
     return result
 
 
@@ -61,7 +60,6 @@ async def register_user(
         name=request.name,
         db=db,
     )
-
     return result
 
 
@@ -81,7 +79,6 @@ async def get_admin(
         uid=uid,
         db=db
     )
-
     return result
 
 
@@ -103,7 +100,6 @@ async def update_admin(
         request=request,
         db=db
     )
-
     return result
 
 
@@ -122,5 +118,4 @@ async def delete_admin(
         uid=uid,
         db=db
     )
-
     return

--- a/src/route/auth_route.py
+++ b/src/route/auth_route.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
 
-from dependency import get_current_active_admin, get_firestore_client
+from dependency import get_async_firestore_client, get_current_active_admin
 from domain.schema.auth_schemas import (
     RouteReqLoginAdmin,
     RouteReqRegisterUser,
@@ -73,7 +73,7 @@ async def register_user(
 async def get_admin(
     uid: str,
     current_user: Annotated[dict, Depends(get_current_active_admin)],
-    db = Depends(get_firestore_client),
+    db = Depends(get_async_firestore_client),
 ):
     result = await service_get_user(
         uid=uid,
@@ -94,7 +94,7 @@ async def update_admin(
     uid: str,
     request: RouteReqUpdateUser,
     current_user: Annotated[dict, Depends(get_current_active_admin)],
-    db = Depends(get_firestore_client),
+    db = Depends(get_async_firestore_client),
 ) -> RouteResUpdateUser:
     result = await service_update_user(
         uid=uid,
@@ -114,7 +114,7 @@ async def update_admin(
 async def delete_admin(
     uid: str,
     current_user: Annotated[dict, Depends(get_current_active_admin)],
-    db = Depends(get_firestore_client),
+    db = Depends(get_async_firestore_client),
 ) -> None:
     await service_delete_user(
         uid=uid,

--- a/src/route/content_route.py
+++ b/src/route/content_route.py
@@ -2,8 +2,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Path, Query, status
 
-from database import get_firestore_client
-from dependency import get_current_active_admin
+from database import get_async_firestore_client
 from domain.schema.content_schemas import (
     RouteReqPostContent,
     RouteReqPutContent,
@@ -35,7 +34,7 @@ router = APIRouter(
 )
 async def get_content(
     post_number: Annotated[int, Path(description="게시글 Post Number", gt=0)],
-    db = Depends(get_firestore_client),
+    db = Depends(get_async_firestore_client),
 ) -> RouteResGetContent:
     response = await service_get_content(
         post_number=post_number,
@@ -59,7 +58,7 @@ async def get_content_list(
     limit: Annotated[
         int, Query(description="페이지 당 게시글 수", example=10,gt=0)
     ] = 10,
-    db = Depends(get_firestore_client),
+    db = Depends(get_async_firestore_client),
 ) -> RouteResGetContentList:
     response = await service_get_content_list(
         page=page,
@@ -78,8 +77,8 @@ async def get_content_list(
 )
 async def create_content(
     content: RouteReqPostContent,
-    current_user: Annotated[dict, Depends(get_current_active_admin)],
-    db = Depends(get_firestore_client),
+    #current_user: Annotated[dict, Depends(get_current_active_admin)],
+    db = Depends(get_async_firestore_client),
 ) -> RouteResGetContent:
     response = await service_create_content(
         content=content,
@@ -98,8 +97,8 @@ async def create_content(
 async def update_content(
     post_number: Annotated[int, Path(description="게시글 Post Number", gt=0)],
     request: RouteReqPutContent,
-    current_user: Annotated[dict, Depends(get_current_active_admin)],
-    db = Depends(get_firestore_client),
+    #current_user: Annotated[dict, Depends(get_current_active_admin)],
+    db = Depends(get_async_firestore_client),
 ) -> RouteResGetContent:
     response = await service_update_content(
         post_number=post_number,
@@ -117,8 +116,8 @@ async def update_content(
 )
 async def delete_content(
     post_number: Annotated[int, Path(description="게시글 Post Number", gt=0)],
-    current_user: Annotated[dict, Depends(get_current_active_admin)],
-    db = Depends(get_firestore_client),
+    #current_user: Annotated[dict, Depends(get_current_active_admin)],
+    db = Depends(get_async_firestore_client),
 ) -> None:
     await service_delete_content(
         post_number=post_number,
@@ -136,8 +135,8 @@ async def delete_content(
 )
 async def get_content_detail(
     post_number: Annotated[int, Path(description="게시글 Post Number", gt=0)],
-    current_user: Annotated[dict, Depends(get_current_active_admin)],
-    db = Depends(get_firestore_client),
+    #current_user: Annotated[dict, Depends(get_current_active_admin)],
+    db = Depends(get_async_firestore_client),
 ) -> RouteResGetContentDetail:
     response = await service_get_content_detail(
         post_number=post_number,

--- a/src/route/content_route.py
+++ b/src/route/content_route.py
@@ -95,12 +95,12 @@ async def create_content(
 )
 async def update_content(
     post_number: Annotated[int, Path(description="게시글 Post Number", gt=0)],
-    content: RouteReqPutContent,
+    request: RouteReqPutContent,
     db = Depends(get_firestore_client),
 ) -> RouteResGetContent:
     response = await service_update_content(
         post_number=post_number,
-        content=content,
+        request=request,
         db=db,
     )
     return response

--- a/src/route/content_route.py
+++ b/src/route/content_route.py
@@ -76,7 +76,7 @@ async def get_content_list(
 )
 async def create_content(
     content: RouteReqPostContent,
-    current_user: Annotated[dict, Depends(get_current_active_admin)], # admin으로 변경하기.
+    current_user: Annotated[dict, Depends(get_current_active_admin)],
     db = Depends(get_firestore_client),
 ) -> RouteResGetContent:
     response = await service_create_content(
@@ -96,6 +96,7 @@ async def create_content(
 async def update_content(
     post_number: Annotated[int, Path(description="게시글 Post Number", gt=0)],
     request: RouteReqPutContent,
+    current_user: Annotated[dict, Depends(get_current_active_admin)],
     db = Depends(get_firestore_client),
 ) -> RouteResGetContent:
     response = await service_update_content(
@@ -114,6 +115,7 @@ async def update_content(
 )
 async def delete_content(
     post_number: Annotated[int, Path(description="게시글 Post Number", gt=0)],
+    current_user: Annotated[dict, Depends(get_current_active_admin)],
     db = Depends(get_firestore_client),
 ) -> None:
     await service_delete_content(

--- a/src/route/content_route.py
+++ b/src/route/content_route.py
@@ -8,12 +8,14 @@ from domain.schema.content_schemas import (
     RouteReqPostContent,
     RouteReqPutContent,
     RouteResGetContent,
+    RouteResGetContentDetail,
     RouteResGetContentList,
 )
 from domain.service.content_services import (
     service_create_content,
     service_delete_content,
     service_get_content,
+    service_get_content_detail,
     service_get_content_list,
     service_update_content,
 )
@@ -123,3 +125,23 @@ async def delete_content(
         db=db,
     )
     return
+
+
+@router.get(
+    "/admin/{post_number}",
+    summary="게시글 상세 조회",
+    description="""게시글을 Post Number로 상세 조회합니다.""",
+    response_model=RouteResGetContentDetail,
+    status_code=status.HTTP_200_OK,
+)
+async def get_content_detail(
+    post_number: Annotated[int, Path(description="게시글 Post Number", gt=0)],
+    current_user: Annotated[dict, Depends(get_current_active_admin)],
+    db = Depends(get_firestore_client),
+) -> RouteResGetContentDetail:
+    response = await service_get_content_detail(
+        post_number=post_number,
+        db=db,
+    )
+
+    return response

--- a/src/route/content_route.py
+++ b/src/route/content_route.py
@@ -4,8 +4,19 @@ from fastapi import APIRouter, Depends, Path, Query, status
 
 from database import get_firestore_client
 from dependency import get_current_active_admin
-from domain.schema.content_schemas import RouteReqPostContent, RouteResGetContent, RouteResGetContentList
-from domain.service.content_services import service_create_content, service_get_content, service_get_content_list
+from domain.schema.content_schemas import (
+    RouteReqPostContent,
+    RouteReqPutContent,
+    RouteResGetContent,
+    RouteResGetContentList,
+)
+from domain.service.content_services import (
+    service_create_content,
+    service_delete_content,
+    service_get_content,
+    service_get_content_list,
+    service_update_content,
+)
 
 router = APIRouter(
     prefix="/content",
@@ -59,6 +70,7 @@ async def get_content_list(
 @router.post(
     "/admin/create",
     summary="게시글 작성",
+    description="""게시글을 작성합니다.""",
     response_model=RouteResGetContent,
     status_code=status.HTTP_200_OK,
 )
@@ -72,3 +84,40 @@ async def create_content(
         db=db,
     )
     return response
+
+
+@router.put(
+    "/admin/{post_number}",
+    summary="게시글 수정",
+    description="""게시글을 수정합니다.""",
+    response_model=RouteResGetContent,
+    status_code=status.HTTP_200_OK,
+)
+async def update_content(
+    post_number: Annotated[int, Path(description="게시글 Post Number", gt=0)],
+    content: RouteReqPutContent,
+    db = Depends(get_firestore_client),
+) -> RouteResGetContent:
+    response = await service_update_content(
+        post_number=post_number,
+        content=content,
+        db=db,
+    )
+    return response
+
+
+@router.delete(
+    "/admin/{post_number}",
+    summary="게시글 삭제",
+    description="""게시글을 삭제합니다.""",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_content(
+    post_number: Annotated[int, Path(description="게시글 Post Number", gt=0)],
+    db = Depends(get_firestore_client),
+) -> None:
+    await service_delete_content(
+        post_number=post_number,
+        db=db,
+    )
+    return

--- a/src/route/content_route.py
+++ b/src/route/content_route.py
@@ -40,7 +40,6 @@ async def get_content(
         post_number=post_number,
         db=db,
     )
-
     return response
 
 
@@ -142,5 +141,4 @@ async def get_content_detail(
         post_number=post_number,
         db=db,
     )
-
     return response

--- a/src/utils/crud_utils.py
+++ b/src/utils/crud_utils.py
@@ -1,0 +1,61 @@
+from google.cloud.firestore import DocumentReference
+from google.cloud.firestore_v1.async_client import AsyncClient
+from google.cloud.firestore_v1.base_query import And, FieldFilter
+
+from domain.service.counter_services import get_async_next_id
+
+
+class FirestoreService:
+    def __init__(self, db: AsyncClient):
+        self.db = db
+
+
+    async def create_document_with_increment_id(
+        self,
+        collection_name: str,
+        key_name: str,
+        data: dict[str, object],
+    ) -> dict[str, object] | None:
+        next_id = await get_async_next_id(collection_name, self.db)
+        if next_id is None:
+            return None
+
+        try:
+            doc_ref: DocumentReference = self.db.collection(collection_name).document()
+            data[f"{key_name}"] = next_id
+            batch = self.db.batch()
+            batch.set(doc_ref, data)
+            await batch.commit() # 비동기 commit 호출
+            return {"document_id": doc_ref.id, f"{key_name}": next_id}
+        except Exception as e:
+            print(f"Error creating document: {e}")
+            return None
+
+
+    async def get_document_by_increment_id(
+        self,
+        collection_name: str,
+        key_name: str,
+        increment_id: int,
+    ) -> dict[str, object] | None:
+        try:
+            query = (
+                self.db.collection(collection_name)
+                .where(
+                    filter=And([
+                        FieldFilter(f"{key_name}", "==", increment_id),
+                        FieldFilter("is_deleted", "==", False)
+                    ])
+                )
+                .limit(1)
+            )
+            result = await query.get()
+            if result:
+                document = result[0]
+                data = document.to_dict()
+                data['document_id'] = document.id  # 문서 ID를 딕셔너리에 추가
+                return data
+            return None
+        except Exception as e:
+            print(f"Error fetching document: {e}")
+            return None


### PR DESCRIPTION
- Client -> AsyncClient 비동기 db로 변경

- GET /content/{post_number}, GET /content, POST /content/admin/create, PUT /content/admin/{post_number}, DELETE /content/admin/{post_number} content 관련 CRUD API 생성
- GET /auth/admin/{uid}, PUT /auth/admin/{uid}, DELETE /auth/admin/{uid} auth 관련 CRUD API 생성

- 아직 content에 category 요소 넣지 않았음. 이건 아예 따로 다른 API로 만들지 고민 중. 
- CRUD 관련해서 공통 부분들 crud_utils.py로 통합이 필요함.